### PR TITLE
处理带空格的图片名

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 module.exports = function(data) {
   data.content = data.content.replace(
-    /!{1}\[([^\[\]]*)\]\((\S*)\s?(?:"(.*)")?\)/g,
+    /!{1}\[([^\[\]]*)\]\((.*\.\S*)\s?(?:"(.*)")?\)/g,
     (_, alt, href, title, str) => {
       if (/^(?:ftp|http|https):.+/.exec(href)) {
         return str;
@@ -10,9 +10,9 @@ module.exports = function(data) {
         throw `[hexo-simple-image] Error when analyze path '${href}', Please use correct image path.`;
       }
       if (regResult[1]) {
-        return `{% asset_img ${regResult[1]} '"${title || ""}" "${alt}"' %}`;
+        return `{% asset_img "${regResult[1]}" '"${title || ""}" "${alt}"' %}`;
       }
-      return `{% asset_img ${regResult[0]} '"${title || ""}" "${alt}"' %}`;
+      return `{% asset_img "${regResult[0]}" '"${title || ""}" "${alt}"' %}`;
     });
   return data;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,7 @@ let data = { content: "" }
  */
 data.content = '![alt](./test/test.png "title")'
 plugin(data)
-if (data.content !== '{% asset_img test.png \'"title" "alt"\' %}')
+if (data.content !== '{% asset_img "test.png" \'"title" "alt"\' %}')
     throw "failed."
 
 /**
@@ -19,7 +19,7 @@ if (data.content !== '{% asset_img test.png \'"title" "alt"\' %}')
  */
 data.content = '![描述](./测试/测试.png "标题")'
 plugin(data)
-if (data.content !== '{% asset_img 测试.png \'"标题" "描述"\' %}')
+if (data.content !== '{% asset_img "测试.png" \'"标题" "描述"\' %}')
     throw "failed."
 
 /**
@@ -27,7 +27,7 @@ if (data.content !== '{% asset_img 测试.png \'"标题" "描述"\' %}')
  */
  data.content = '![alt](test/test.png "title")'
  plugin(data)
- if (data.content !== '{% asset_img test.png \'"title" "alt"\' %}')
+ if (data.content !== '{% asset_img "test.png" \'"title" "alt"\' %}')
      throw "failed."
 
 /**
@@ -35,7 +35,15 @@ if (data.content !== '{% asset_img 测试.png \'"标题" "描述"\' %}')
  */
  data.content = '![alt](test/test.png)'
  plugin(data)
- if (data.content !== '{% asset_img test.png \'"" "alt"\' %}')
+ if (data.content !== '{% asset_img "test.png" \'"" "alt"\' %}')
      throw "failed."
+
+/**
+ * 5. path with whitespace
+ */
+data.content = '![alt](test/this is test.png)'
+plugin(data)
+if (data.content !== '{% asset_img "this is test.png" \'"" "alt"\' %}')
+    throw "failed."
 
 console.log("success.")


### PR DESCRIPTION
图片名称中带有空格，导致图片路径中带有空格，无法被转换成`asset_img`